### PR TITLE
91 emergency repair identification priority list page options

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@babel/preset-react": "^7.14.5",
     "babel-eslint": "^10.1.0",
     "cypress": "^8.4.0",
+    "cypress-react-selector": "^2.3.11",
     "eslint": "^7.32.0",
     "eslint-plugin-editorconfig": "^3.0.2",
     "eslint-plugin-react": "^7.25.1",

--- a/src/components/reportRepair.js
+++ b/src/components/reportRepair.js
@@ -5,7 +5,8 @@ import Confirmation from './reportRepair/confirmation';
 import PriorityList from './reportRepair/priorityList';
 import EmergencyRepair from './reportRepair/emergencyRepair';
 import NotEligible from './reportRepair/notEligible';
-import SmellGass from './reportRepair/smellGas';
+import SmellGas from './reportRepair/smellGas';
+import Communal from './reportRepair/communal';
 import { BackLink } from 'govuk-react';
 import Flow from '../flow';
 import {
@@ -19,7 +20,7 @@ import {
 export default function Report() {
   let history = useHistory();
   let { path, url } = useRouteMatch();
-  const [state, setState] = useState({data:{}, step: 'postcode'});
+  const [state, setState] = useState({data:{}, step: 'priority-list'});
   const flow = new Flow(setState, history, path)
   const prevStep = () => {
     flow.prevStep(state)
@@ -35,10 +36,15 @@ export default function Report() {
       <BackLink onClick={prevStep}>Back</BackLink>
       <Switch>
         <Route exact path={path}>
-          <Redirect to={`${path}/postcode`} />
+          <Redirect to={`${path}/priority-list`} />
         </Route>
         <Route path={`${path}/priority-list`}>
           <PriorityList
+            handleChange={handleChange}
+            values={values}/>
+        </Route>
+        <Route path={`${path}/communal`}>
+          <Communal
             handleChange={handleChange}
             values={values}/>
         </Route>
@@ -63,7 +69,7 @@ export default function Report() {
           <NotEligible/>
         </Route>
         <Route path={`${path}/smell-gas`}>
-          <SmellGass/>
+          <SmellGas/>
         </Route>
       </Switch>
     </div>

--- a/src/components/reportRepair.js
+++ b/src/components/reportRepair.js
@@ -30,9 +30,6 @@ export default function Report() {
 
   useEffect(() => {
     return history.listen(location => {
-      if (history.action === 'PUSH') {
-        setLocationKeys([ location.key ])
-      }
 
       if (history.action === 'POP') {
         if (locationKeys[1] !== location.key) {
@@ -41,7 +38,7 @@ export default function Report() {
         }
       }
     })
-  }, [ locationKeys, ])
+  }, [ locationKeys ])
 
   const handleChange = (input, value) => {
     flow.handleChange(input,value,state)

--- a/src/components/reportRepair.js
+++ b/src/components/reportRepair.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, {useEffect, useState} from 'react';
 import Postcode from './reportRepair/postcode';
 import Address from './reportRepair/address';
 import Confirmation from './reportRepair/confirmation';
@@ -25,6 +25,23 @@ export default function Report() {
   const prevStep = () => {
     flow.prevStep(state)
   }
+
+  const [ locationKeys, setLocationKeys ] = useState([])
+
+  useEffect(() => {
+    return history.listen(location => {
+      if (history.action === 'PUSH') {
+        setLocationKeys([ location.key ])
+      }
+
+      if (history.action === 'POP') {
+        if (locationKeys[1] !== location.key) {
+          setLocationKeys((keys) => [ location.key, ...keys ])
+          prevStep();
+        }
+      }
+    })
+  }, [ locationKeys, ])
 
   const handleChange = (input, value) => {
     flow.handleChange(input,value,state)

--- a/src/components/reportRepair.js
+++ b/src/components/reportRepair.js
@@ -5,6 +5,7 @@ import Confirmation from './reportRepair/confirmation';
 import PriorityList from './reportRepair/priorityList';
 import EmergencyRepair from './reportRepair/emergencyRepair';
 import NotEligible from './reportRepair/notEligible';
+import SmellGass from './reportRepair/smellGas';
 import { BackLink } from 'govuk-react';
 import Flow from '../flow';
 import {
@@ -60,6 +61,9 @@ export default function Report() {
         </Route>
         <Route path={`${path}/not-eligible`}>
           <NotEligible/>
+        </Route>
+        <Route path={`${path}/smell-gas`}>
+          <SmellGass/>
         </Route>
       </Switch>
     </div>

--- a/src/components/reportRepair/communal.js
+++ b/src/components/reportRepair/communal.js
@@ -24,9 +24,11 @@ const Communal = ({handleChange, nextStep, values}) => {
             <Radio name="communal" value="yes">Yes</Radio>
             <Radio name="communal" value="no">No</Radio>
           </FormGroup>
-          <Details summary="Which areas are communal?" className="govuk-!-margin-top-6" data-testid="landing-page-gas-prompt">
-            Communal areas are any spaces that are shared with other residents. <br/>
-            For example, this would include gardens, lifts, corridors, or car parks.
+          <Details summary="Which areas are communal?" className="govuk-!-margin-top-6" data-testid="communal-area-prompt">
+            <span data-testid="communal-area-info">
+              Communal areas are any spaces that are shared with other residents. <br/>
+              For example, this would include gardens, lifts, corridors, or car parks.
+            </span>
           </Details>
           <Button onClick={Continue} >Continue</Button>
         </form>

--- a/src/components/reportRepair/communal.js
+++ b/src/components/reportRepair/communal.js
@@ -1,0 +1,44 @@
+import PropTypes from 'prop-types';
+import {
+  Button,
+  Radio,
+  GridRow,
+  GridCol,
+  Fieldset,
+  FormGroup, Details
+} from 'govuk-react'
+
+
+const Communal = ({handleChange, nextStep, values}) => {
+  const Continue = e => {
+    e.preventDefault();
+    const el = document.querySelector('input[name="communal"]:checked');
+    handleChange('communal', el.value);
+  }
+  return <GridRow>
+    <GridCol setWidth="two-third">
+      <Fieldset>
+        <Fieldset.Legend size="XL" isPageHeading>Is the issue in a communal area?</Fieldset.Legend>
+        <form action="">
+          <FormGroup>
+            <Radio name="communal" value="yes">Yes</Radio>
+            <Radio name="communal" value="no">No</Radio>
+          </FormGroup>
+          <Details summary="Which areas are communal?" className="govuk-!-margin-top-6" data-testid="landing-page-gas-prompt">
+            Communal areas are any spaces that are shared with other residents. <br/>
+            For example, this would include gardens, lifts, corridors, or car parks.
+          </Details>
+          <Button onClick={Continue} >Continue</Button>
+        </form>
+      </Fieldset>
+    </GridCol>
+  </GridRow>
+};
+
+Communal.propTypes = {
+  nextStep: PropTypes.func,
+  values: PropTypes.object,
+  handleChange: PropTypes.func,
+}
+
+export default Communal;

--- a/src/components/reportRepair/notEligible.js
+++ b/src/components/reportRepair/notEligible.js
@@ -4,7 +4,13 @@ const NotEligible = () => {
 
   return <GridRow>
     <GridCol setWidth="two-thirds">
-      <H1>Not eligible</H1>
+      <H1>The council may not be responsible for repairs at this property</H1>
+      <Paragraph>
+        If you think the council is responsible for your property, please call **0800 952 4444**.
+      </Paragraph>
+      <Paragraph>
+        You can also view the progress of any reported communal breakdown on the same page.
+      </Paragraph>
     </GridCol>
   </GridRow>
 };

--- a/src/components/reportRepair/priorityList.js
+++ b/src/components/reportRepair/priorityList.js
@@ -4,26 +4,32 @@ import {
   Radio,
   GridRow,
   GridCol,
-  MultiChoice,
-  Fieldset, FormGroup, InputField
+  Fieldset,
+  FormGroup
 } from 'govuk-react'
 
 
 const PriorityList = ({handleChange, nextStep, values}) => {
   const Continue = e => {
     e.preventDefault();
-    const el = document.querySelector('input[name="type"]:checked');
-    const typeOfRepair = el.value
-    handleChange('typeOfRepair', typeOfRepair);
+    const el = document.querySelector('input[name="priority-list"]:checked');
+    handleChange('priority-list', el.value);
   }
   return <GridRow>
     <GridCol setWidth="two-third">
       <Fieldset>
-        <Fieldset.Legend size="XL" isPageHeading>Is this an emergency?</Fieldset.Legend>
+        <Fieldset.Legend size="XL" isPageHeading>What is the problem?</Fieldset.Legend>
         <form action="">
           <FormGroup>
-            <Radio name="type" value="emergency">Yes</Radio>
-            <Radio name="type" value="non-emergency">No</Radio>
+            <Radio name="priority-list" value="gas-emergency">I can smell gas</Radio>
+            <Radio name="priority-list" value="emergency">I have no heating</Radio>
+            <Radio name="priority-list" value="emergency">I have no water</Radio>
+            <Radio name="priority-list" value="emergency">I have no electricity</Radio>
+            <Radio name="priority-list" value="emergency">I have water leaking on to electrics</Radio>
+            <Radio name="priority-list" value="emergency">I can&apos;t secure my property</Radio>
+            <Radio name="priority-list" value="emergency">I have exposed wiring or sockets</Radio>
+            <Radio name="priority-list" value="emergency">My carbon monoxide or smoke alarm is beeping</Radio>
+            <Radio name="priority-list" value="non-emergency">Something else</Radio>
           </FormGroup>
           <Button onClick={Continue} >Continue</Button>
         </form>

--- a/src/components/reportRepair/smellGas.js
+++ b/src/components/reportRepair/smellGas.js
@@ -1,0 +1,15 @@
+import { H1, GridRow, GridCol, Paragraph } from 'govuk-react'
+
+const SmellGass = () => {
+
+  return <GridRow>
+    <GridCol setWidth="two-thirds">
+      <H1>If you smell gas</H1>
+      <Paragraph>
+        If you can smell gas, please call the gas emergency number: 0800 111 999
+      </Paragraph>
+    </GridCol>
+  </GridRow>
+};
+
+export default SmellGass;

--- a/src/components/reportRepair/smellGas.js
+++ b/src/components/reportRepair/smellGas.js
@@ -1,6 +1,6 @@
 import { H1, GridRow, GridCol, Paragraph } from 'govuk-react'
 
-const SmellGass = () => {
+const SmellGas = () => {
 
   return <GridRow>
     <GridCol setWidth="two-thirds">
@@ -12,4 +12,4 @@ const SmellGass = () => {
   </GridRow>
 };
 
-export default SmellGass;
+export default SmellGas;

--- a/src/flow.js
+++ b/src/flow.js
@@ -4,14 +4,17 @@ export default class Flow {
     this.history = history;
     this.path = path;
     this.flow =     this.flow = {
-      'postcode': {prevStep: false, nextStep: 'address'},
-      'address': {prevStep: 'postcode', nextStep: 'priority-list'},
       'priority-list': {prevStep: 'address', nextStep: [
         {condition: 'gas-emergency', nextStep: 'smell-gas'},
         {condition: 'emergency', nextStep: 'emergency-repair'},
-        {condition: 'non-emergency', nextStep: 'prior-repair'}
+        {condition: 'non-emergency', nextStep: 'communal'}
       ]},
-      'prior-repair': {prevStep:'priority-list', nextStep: 'repair-location'},
+      'communal': {prevStep: 'priority-list', nextStep: [
+        {condition: 'yes', nextStep: 'not-eligible'},
+        {condition: 'no', nextStep: 'postcode'}
+      ]},
+      'postcode': {prevStep: 'resident-type', nextStep: 'address'},
+      'address': {prevStep: 'postcode', nextStep: 'repair-location'},
       'repair-location': { prevStep: 'prior-repair', nextStep: 'repair-type'},
       'repair-type': { prevStep: 'repair-location', nextStep: [
         {condition: 'cupboards-or-worktops', nextStep: 'repair-description'},

--- a/src/flow.js
+++ b/src/flow.js
@@ -111,18 +111,14 @@ export default class Flow {
     // workout what the new previous step should be.
     if (this._prevStepIsNotDefinedOrEqualsCurrentStep(state)) {
       if (this._prevStepIsInFlow(state)) {
-        console.log(state)
         state.prevStep = this.flow[state.step].prevStep
-        console.log('11111')
       } else {
-        console.log('22222')
         return this.history.push('/')
       }
     }
 
     state.step = state.prevStep
     this.setState(state);
-    console.log('set state', state)
     this.history.push(`${this.path}/${state.prevStep}`)
   }
   handleChange = (input, value, state) => {

--- a/src/flow.js
+++ b/src/flow.js
@@ -3,8 +3,8 @@ export default class Flow {
     this.setState = setState;
     this.history = history;
     this.path = path;
-    this.flow =     this.flow = {
-      'priority-list': {prevStep: 'address', nextStep: [
+    this.flow = {
+      'priority-list': {prevStep: false, nextStep: [
         {condition: 'gas-emergency', nextStep: 'smell-gas'},
         {condition: 'emergency', nextStep: 'emergency-repair'},
         {condition: 'non-emergency', nextStep: 'communal'}
@@ -13,7 +13,7 @@ export default class Flow {
         {condition: 'yes', nextStep: 'not-eligible'},
         {condition: 'no', nextStep: 'postcode'}
       ]},
-      'postcode': {prevStep: 'resident-type', nextStep: 'address'},
+      'postcode': {prevStep: 'communal', nextStep: 'address'},
       'address': {prevStep: 'postcode', nextStep: 'repair-location'},
       'repair-location': { prevStep: 'prior-repair', nextStep: 'repair-type'},
       'repair-type': { prevStep: 'repair-location', nextStep: [
@@ -111,13 +111,18 @@ export default class Flow {
     // workout what the new previous step should be.
     if (this._prevStepIsNotDefinedOrEqualsCurrentStep(state)) {
       if (this._prevStepIsInFlow(state)) {
+        console.log(state)
         state.prevStep = this.flow[state.step].prevStep
+        console.log('11111')
       } else {
+        console.log('22222')
         return this.history.push('/')
       }
     }
+
     state.step = state.prevStep
     this.setState(state);
+    console.log('set state', state)
     this.history.push(`${this.path}/${state.prevStep}`)
   }
   handleChange = (input, value, state) => {

--- a/tests/cypress/integration/reportRepair/communal.spec.js
+++ b/tests/cypress/integration/reportRepair/communal.spec.js
@@ -1,0 +1,27 @@
+describe('priorityList', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:3000/report-repair/');
+    cy.contains('Something else').click();
+    cy.get('button').click()
+  });
+
+  it('displays the question', () => {
+    cy.contains('Is the issue in a communal area?');
+  });
+
+  context('When a user selects: Yes', ()=>{
+    it('should redirect them to smell gas page',  () => {
+      cy.contains('Yes').click();
+      cy.get('button').click()
+      cy.url().should('include', '/report-repair/not-eligible');
+    });
+  });
+
+  context('When a user selects: No', ()=>{
+    it('should redirect them to smell gas page',  () => {
+      cy.contains('No').click();
+      cy.get('button').click()
+      cy.url().should('include', '/report-repair/postcode');
+    });
+  })
+});

--- a/tests/cypress/integration/reportRepair/communal.spec.js
+++ b/tests/cypress/integration/reportRepair/communal.spec.js
@@ -1,4 +1,4 @@
-describe('priorityList', () => {
+describe('communal', () => {
   beforeEach(() => {
     cy.visit('http://localhost:3000/report-repair/');
     cy.contains('Something else').click();

--- a/tests/cypress/integration/reportRepair/communal.spec.js
+++ b/tests/cypress/integration/reportRepair/communal.spec.js
@@ -9,6 +9,27 @@ describe('priorityList', () => {
     cy.contains('Is the issue in a communal area?');
   });
 
+  context('communal area prompt', () => {
+    it('displays text', () => {
+      cy.get('[data-testid=communal-area-prompt]').should(
+        'have.contain',
+        'Which areas are communal?'
+      );
+    });
+
+    it('displays instructions when clicked', () => {
+      cy.get('details > summary')
+        .click()
+        .then(() => {
+          cy.get('[data-testid=communal-area-info]').should('be.visible').should(
+            'contain',
+            'Communal areas are any spaces that are shared with other residents.' +
+            ' For example, this would include gardens, lifts, corridors, or car parks.'
+          );
+        });
+    });
+  });
+
   context('When a user selects: Yes', ()=>{
     it('should redirect them to smell gas page',  () => {
       cy.contains('Yes').click();

--- a/tests/cypress/integration/reportRepair/priorityList.spec.js
+++ b/tests/cypress/integration/reportRepair/priorityList.spec.js
@@ -109,7 +109,7 @@ describe('priorityList', () => {
       cy.get('button').click();
       cy.go('back')
       cy.go('back')
-      cy.url().should('eq', 'http://localhost:3000/report-repair');
+      cy.url().should('eq', 'http://localhost:3000/');
     })
   })
 });

--- a/tests/cypress/integration/reportRepair/priorityList.spec.js
+++ b/tests/cypress/integration/reportRepair/priorityList.spec.js
@@ -103,7 +103,7 @@ describe('priorityList', () => {
     })
   })
 
-  context('User presses the back button twice from an eit page', ()=>{
+  context('User presses the back button twice from an exit page', ()=>{
     it('should redirect the user to the home page',  () => {
       cy.contains('I can smell gas').click();
       cy.get('button').click();

--- a/tests/cypress/integration/reportRepair/priorityList.spec.js
+++ b/tests/cypress/integration/reportRepair/priorityList.spec.js
@@ -80,4 +80,26 @@ describe('priorityList', () => {
       cy.url().should('include', '/report-repair/communal');
     });
   })
+
+  context('User uses back buttons to navigate out of an exit page and selects a different option', ()=>{
+    it('should redirect the user to a different exit page',  () => {
+      cy.contains('I can smell gas').click();
+      cy.get('button').click();
+      cy.go('back')
+      cy.contains('I have no heating').click();
+      cy.get('button').click()
+      cy.url().should('include', '/report-repair/emergency-repair');
+    })
+  })
+
+  context('User uses back buttons to navigate out of an exit page and selects the same option', ()=>{
+    it('should redirect the user to a different exit page',  () => {
+      cy.contains('I can smell gas').click();
+      cy.get('button').click();
+      cy.go('back')
+      cy.contains('I can smell gas').click();
+      cy.get('button').click()
+      cy.url().should('include', '/report-repair/smell-gas');
+    })
+  })
 });

--- a/tests/cypress/integration/reportRepair/priorityList.spec.js
+++ b/tests/cypress/integration/reportRepair/priorityList.spec.js
@@ -1,11 +1,9 @@
 describe('priorityList', () => {
   beforeEach(() => {
     cy.visit('http://localhost:3000/report-repair/');
-    cy.get('button').click()
-    cy.get('button').click()
   });
 
-  it('displays service title', () => {
+  it('displays the question title', () => {
     cy.contains('What is the problem?');
   });
 

--- a/tests/cypress/integration/reportRepair/priorityList.spec.js
+++ b/tests/cypress/integration/reportRepair/priorityList.spec.js
@@ -3,11 +3,11 @@ describe('priorityList', () => {
     cy.visit('http://localhost:3000/report-repair/');
   });
 
-  xit('displays the question title', () => {
+  it('displays the question title', () => {
     cy.contains('What is the problem?');
   });
 
-  xcontext('When a user selects: I can smell gas', ()=>{
+  context('When a user selects: I can smell gas', ()=>{
     it('should redirect them to smell gas page',  () => {
       cy.contains('I can smell gas').click();
       cy.get('button').click()
@@ -15,7 +15,7 @@ describe('priorityList', () => {
     });
   });
 
-  xcontext('When a user selects: I have no heating', ()=>{
+  context('When a user selects: I have no heating', ()=>{
     it('should redirect them to emergency page',  () => {
       cy.contains('I have no heating').click();
       cy.get('button').click()
@@ -24,7 +24,7 @@ describe('priorityList', () => {
   })
 
 
-  xcontext('When a user selects: I have no water', ()=>{
+  context('When a user selects: I have no water', ()=>{
     it('should redirect them to emergency page',  () => {
       cy.contains('I have no water').click();
       cy.get('button').click()
@@ -33,7 +33,7 @@ describe('priorityList', () => {
   })
 
 
-  xcontext('When a user selects: I have no electricity', ()=>{
+  context('When a user selects: I have no electricity', ()=>{
     it('should redirect them to emergency page',  () => {
       cy.contains('I have no electricity').click();
       cy.get('button').click()
@@ -41,7 +41,7 @@ describe('priorityList', () => {
     });
   });
 
-  xcontext('When a user selects: I have water leaking on to electrics', ()=>{
+  context('When a user selects: I have water leaking on to electrics', ()=>{
     it('should redirect them to emergency page',  () => {
       cy.contains('I have water leaking on to electrics').click();
       cy.get('button').click()
@@ -49,7 +49,7 @@ describe('priorityList', () => {
     });
   });
 
-  xcontext('When a user selects: I can\'t secure my property', ()=>{
+  context('When a user selects: I can\'t secure my property', ()=>{
     it('should redirect them to emergency page',  () => {
       cy.contains('I can\'t secure my property').click();
       cy.get('button').click()
@@ -57,7 +57,7 @@ describe('priorityList', () => {
     });
   });
 
-  xcontext('When a user selects: I have exposed wiring or sockets', ()=>{
+  context('When a user selects: I have exposed wiring or sockets', ()=>{
     it('should redirect them to emergency page',  () => {
       cy.contains('I have exposed wiring or sockets').click();
       cy.get('button').click()
@@ -65,7 +65,7 @@ describe('priorityList', () => {
     });
   });
 
-  xcontext('When a user selects: My carbon monoxide or smoke alarm is beeping', ()=>{
+  context('When a user selects: My carbon monoxide or smoke alarm is beeping', ()=>{
     it('should redirect them to emergency page',  () => {
       cy.contains('My carbon monoxide or smoke alarm is beeping').click();
       cy.get('button').click()
@@ -73,7 +73,7 @@ describe('priorityList', () => {
     });
   });
 
-  xcontext('When a user selects: Something else', ()=>{
+  context('When a user selects: Something else', ()=>{
     it('should redirect them to communal page',  () => {
       cy.contains('Something else').click();
       cy.get('button').click()
@@ -81,8 +81,8 @@ describe('priorityList', () => {
     });
   })
 
-  xcontext('User uses back buttons to navigate out of an exit page and selects a different option', ()=>{
-    it('should redirect the user to a different exit page',  () => {
+  context('User uses back buttons to navigate out of an eit page and selects a different option', ()=>{
+    it('should redirect the user to a different eit page',  () => {
       cy.contains('I can smell gas').click();
       cy.get('button').click();
       cy.go('back')
@@ -92,8 +92,8 @@ describe('priorityList', () => {
     })
   })
 
-  xcontext('User uses back buttons to navigate out of an exit page and selects the same option', ()=>{
-    it('should redirect the user to the same exit page',  () => {
+  context('User uses back buttons to navigate out of an eit page and selects the same option', ()=>{
+    it('should redirect the user to the same eit page',  () => {
       cy.contains('I can smell gas').click();
       cy.get('button').click();
       cy.go('back')
@@ -103,7 +103,7 @@ describe('priorityList', () => {
     })
   })
 
-  context('User presses the back button twice from an exit page', ()=>{
+  context('User presses the back button twice from an eit page', ()=>{
     it('should redirect the user to the home page',  () => {
       cy.contains('I can smell gas').click();
       cy.get('button').click();

--- a/tests/cypress/integration/reportRepair/priorityList.spec.js
+++ b/tests/cypress/integration/reportRepair/priorityList.spec.js
@@ -16,7 +16,7 @@ describe('priorityList', () => {
   });
 
   context('When a user selects: I have no heating', ()=>{
-    it('should redirect them to smell gas page',  () => {
+    it('should redirect them to emergency page',  () => {
       cy.contains('I have no heating').click();
       cy.get('button').click()
       cy.url().should('include', '/report-repair/emergency-repair');
@@ -25,7 +25,7 @@ describe('priorityList', () => {
 
 
   context('When a user selects: I have no water', ()=>{
-    it('should redirect them to smell gas page',  () => {
+    it('should redirect them to emergency page',  () => {
       cy.contains('I have no water').click();
       cy.get('button').click()
       cy.url().should('include', '/report-repair/emergency-repair');
@@ -34,7 +34,7 @@ describe('priorityList', () => {
 
 
   context('When a user selects: I have no electricity', ()=>{
-    it('should redirect them to smell gas page',  () => {
+    it('should redirect them to emergency page',  () => {
       cy.contains('I have no electricity').click();
       cy.get('button').click()
       cy.url().should('include', '/report-repair/emergency-repair');
@@ -42,7 +42,7 @@ describe('priorityList', () => {
   });
 
   context('When a user selects: I have water leaking on to electrics', ()=>{
-    it('should redirect them to smell gas page',  () => {
+    it('should redirect them to emergency page',  () => {
       cy.contains('I have water leaking on to electrics').click();
       cy.get('button').click()
       cy.url().should('include', '/report-repair/emergency-repair');
@@ -50,7 +50,7 @@ describe('priorityList', () => {
   });
 
   context('When a user selects: I can\'t secure my property', ()=>{
-    it('should redirect them to smell gas page',  () => {
+    it('should redirect them to emergency page',  () => {
       cy.contains('I can\'t secure my property').click();
       cy.get('button').click()
       cy.url().should('include', '/report-repair/emergency-repair');
@@ -58,7 +58,7 @@ describe('priorityList', () => {
   });
 
   context('When a user selects: I have exposed wiring or sockets', ()=>{
-    it('should redirect them to smell gas page',  () => {
+    it('should redirect them to emergency page',  () => {
       cy.contains('I have exposed wiring or sockets').click();
       cy.get('button').click()
       cy.url().should('include', '/report-repair/emergency-repair');
@@ -66,7 +66,7 @@ describe('priorityList', () => {
   });
 
   context('When a user selects: My carbon monoxide or smoke alarm is beeping', ()=>{
-    it('should redirect them to smell gas page',  () => {
+    it('should redirect them to emergency page',  () => {
       cy.contains('My carbon monoxide or smoke alarm is beeping').click();
       cy.get('button').click()
       cy.url().should('include', '/report-repair/emergency-repair');
@@ -74,10 +74,10 @@ describe('priorityList', () => {
   });
 
   context('When a user selects: Something else', ()=>{
-    it('should redirect them to smell gas page',  () => {
+    it('should redirect them to communal page',  () => {
       cy.contains('Something else').click();
       cy.get('button').click()
-      cy.url().should('include', '/report-repair/prior-repair');
+      cy.url().should('include', '/report-repair/communal');
     });
   })
 });

--- a/tests/cypress/integration/reportRepair/priorityList.spec.js
+++ b/tests/cypress/integration/reportRepair/priorityList.spec.js
@@ -1,0 +1,85 @@
+describe('priorityList', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:3000/report-repair/');
+    cy.get('button').click()
+    cy.get('button').click()
+  });
+
+  it('displays service title', () => {
+    cy.contains('What is the problem?');
+  });
+
+  context('When a user selects: I can smell gas', ()=>{
+    it('should redirect them to smell gas page',  () => {
+      cy.contains('I can smell gas').click();
+      cy.get('button').click()
+      cy.url().should('include', '/report-repair/smell-gas');
+    });
+  });
+
+  context('When a user selects: I have no heating', ()=>{
+    it('should redirect them to smell gas page',  () => {
+      cy.contains('I have no heating').click();
+      cy.get('button').click()
+      cy.url().should('include', '/report-repair/emergency-repair');
+    });
+  })
+
+
+  context('When a user selects: I have no water', ()=>{
+    it('should redirect them to smell gas page',  () => {
+      cy.contains('I have no water').click();
+      cy.get('button').click()
+      cy.url().should('include', '/report-repair/emergency-repair');
+    });
+  })
+
+
+  context('When a user selects: I have no electricity', ()=>{
+    it('should redirect them to smell gas page',  () => {
+      cy.contains('I have no electricity').click();
+      cy.get('button').click()
+      cy.url().should('include', '/report-repair/emergency-repair');
+    });
+  });
+
+  context('When a user selects: I have water leaking on to electrics', ()=>{
+    it('should redirect them to smell gas page',  () => {
+      cy.contains('I have water leaking on to electrics').click();
+      cy.get('button').click()
+      cy.url().should('include', '/report-repair/emergency-repair');
+    });
+  });
+
+  context('When a user selects: I can\'t secure my property', ()=>{
+    it('should redirect them to smell gas page',  () => {
+      cy.contains('I can\'t secure my property').click();
+      cy.get('button').click()
+      cy.url().should('include', '/report-repair/emergency-repair');
+    });
+  });
+
+  context('When a user selects: I have exposed wiring or sockets', ()=>{
+    it('should redirect them to smell gas page',  () => {
+      cy.contains('I have exposed wiring or sockets').click();
+      cy.get('button').click()
+      cy.url().should('include', '/report-repair/emergency-repair');
+    });
+  });
+
+  context('When a user selects: My carbon monoxide or smoke alarm is beeping', ()=>{
+    it('should redirect them to smell gas page',  () => {
+      cy.contains('My carbon monoxide or smoke alarm is beeping').click();
+      cy.get('button').click()
+      cy.url().should('include', '/report-repair/emergency-repair');
+    });
+  });
+
+  context('When a user selects: Something else', ()=>{
+    it('should redirect them to smell gas page',  () => {
+      cy.contains('Something else').click();
+      cy.get('button').click()
+      cy.url().should('include', '/report-repair/prior-repair');
+    });
+  })
+});

--- a/tests/cypress/integration/reportRepair/priorityList.spec.js
+++ b/tests/cypress/integration/reportRepair/priorityList.spec.js
@@ -3,11 +3,11 @@ describe('priorityList', () => {
     cy.visit('http://localhost:3000/report-repair/');
   });
 
-  it('displays the question title', () => {
+  xit('displays the question title', () => {
     cy.contains('What is the problem?');
   });
 
-  context('When a user selects: I can smell gas', ()=>{
+  xcontext('When a user selects: I can smell gas', ()=>{
     it('should redirect them to smell gas page',  () => {
       cy.contains('I can smell gas').click();
       cy.get('button').click()
@@ -15,7 +15,7 @@ describe('priorityList', () => {
     });
   });
 
-  context('When a user selects: I have no heating', ()=>{
+  xcontext('When a user selects: I have no heating', ()=>{
     it('should redirect them to emergency page',  () => {
       cy.contains('I have no heating').click();
       cy.get('button').click()
@@ -24,7 +24,7 @@ describe('priorityList', () => {
   })
 
 
-  context('When a user selects: I have no water', ()=>{
+  xcontext('When a user selects: I have no water', ()=>{
     it('should redirect them to emergency page',  () => {
       cy.contains('I have no water').click();
       cy.get('button').click()
@@ -33,7 +33,7 @@ describe('priorityList', () => {
   })
 
 
-  context('When a user selects: I have no electricity', ()=>{
+  xcontext('When a user selects: I have no electricity', ()=>{
     it('should redirect them to emergency page',  () => {
       cy.contains('I have no electricity').click();
       cy.get('button').click()
@@ -41,7 +41,7 @@ describe('priorityList', () => {
     });
   });
 
-  context('When a user selects: I have water leaking on to electrics', ()=>{
+  xcontext('When a user selects: I have water leaking on to electrics', ()=>{
     it('should redirect them to emergency page',  () => {
       cy.contains('I have water leaking on to electrics').click();
       cy.get('button').click()
@@ -49,7 +49,7 @@ describe('priorityList', () => {
     });
   });
 
-  context('When a user selects: I can\'t secure my property', ()=>{
+  xcontext('When a user selects: I can\'t secure my property', ()=>{
     it('should redirect them to emergency page',  () => {
       cy.contains('I can\'t secure my property').click();
       cy.get('button').click()
@@ -57,7 +57,7 @@ describe('priorityList', () => {
     });
   });
 
-  context('When a user selects: I have exposed wiring or sockets', ()=>{
+  xcontext('When a user selects: I have exposed wiring or sockets', ()=>{
     it('should redirect them to emergency page',  () => {
       cy.contains('I have exposed wiring or sockets').click();
       cy.get('button').click()
@@ -65,7 +65,7 @@ describe('priorityList', () => {
     });
   });
 
-  context('When a user selects: My carbon monoxide or smoke alarm is beeping', ()=>{
+  xcontext('When a user selects: My carbon monoxide or smoke alarm is beeping', ()=>{
     it('should redirect them to emergency page',  () => {
       cy.contains('My carbon monoxide or smoke alarm is beeping').click();
       cy.get('button').click()
@@ -73,7 +73,7 @@ describe('priorityList', () => {
     });
   });
 
-  context('When a user selects: Something else', ()=>{
+  xcontext('When a user selects: Something else', ()=>{
     it('should redirect them to communal page',  () => {
       cy.contains('Something else').click();
       cy.get('button').click()
@@ -81,7 +81,7 @@ describe('priorityList', () => {
     });
   })
 
-  context('User uses back buttons to navigate out of an exit page and selects a different option', ()=>{
+  xcontext('User uses back buttons to navigate out of an exit page and selects a different option', ()=>{
     it('should redirect the user to a different exit page',  () => {
       cy.contains('I can smell gas').click();
       cy.get('button').click();
@@ -92,14 +92,24 @@ describe('priorityList', () => {
     })
   })
 
-  context('User uses back buttons to navigate out of an exit page and selects the same option', ()=>{
-    it('should redirect the user to a different exit page',  () => {
+  xcontext('User uses back buttons to navigate out of an exit page and selects the same option', ()=>{
+    it('should redirect the user to the same exit page',  () => {
       cy.contains('I can smell gas').click();
       cy.get('button').click();
       cy.go('back')
       cy.contains('I can smell gas').click();
       cy.get('button').click()
       cy.url().should('include', '/report-repair/smell-gas');
+    })
+  })
+
+  context('User presses the back button twice from an exit page', ()=>{
+    it('should redirect the user to the home page',  () => {
+      cy.contains('I can smell gas').click();
+      cy.get('button').click();
+      cy.go('back')
+      cy.go('back')
+      cy.url().should('eq', 'http://localhost:3000/report-repair');
     })
   })
 });

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -15,6 +15,7 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
+import 'cypress-react-selector';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/tests/unit/flow.test.js
+++ b/tests/unit/flow.test.js
@@ -190,12 +190,12 @@ describe('Flow', () => {
         flow.handleChange('field', 'value', {step: 'emergency', data: {}});
         expect(setStateSpy).toHaveBeenCalledWith({
           prevStep: 'priority-list',
-          step: 'prior-repair',
+          step: 'communal',
           data: {
             'field': 'value'
           }
         });
-        expect(historySpy.push).toHaveBeenCalledWith(`${pathDummy}/prior-repair`);
+        expect(historySpy.push).toHaveBeenCalledWith(`${pathDummy}/communal`);
       });
     })
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4764,6 +4764,13 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+cypress-react-selector@^2.3.11:
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/cypress-react-selector/-/cypress-react-selector-2.3.11.tgz#0b732c327f7b329ae67ea4efbe727436c9e0f2e3"
+  integrity sha512-oWdVkBiXKpf4oHCcSBs2FGf8egJu7l8Rfi5Y9sbSk7kfq4cQRnQVnvmjWER1FkJRd/4tcwAO/Ku+Qw9XJsyxIw==
+  dependencies:
+    resq "1.10.1"
+
 cypress@^8.4.0:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-8.4.0.tgz#09ec06a73f1cb10121c103cba15076e659e24876"
@@ -5913,6 +5920,11 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -11013,6 +11025,13 @@ resolve@^2.0.0-next.3:
   dependencies:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
+
+resq@1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/resq/-/resq-1.10.1.tgz#c05d1b3808016cceec4d485ceb375acb49565f53"
+  integrity sha512-zhp1iyUH02MLciv3bIM2bNtTFx/fqRsK4Jk73jcPqp00d/sMTTjOtjdTMAcgjrQKGx5DvQ/HSpeqaMW0atGRJA==
+  dependencies:
+    fast-deep-equal "^2.0.1"
 
 restore-cursor@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
In this PR:
- [x] Reorganised the user journey to reflect [beta prototype V2](https://southwark-repairs-alpha-master.herokuapp.com/beta/v2/)
- [x] Add smell gas page
- [x] Add communal page
- [x] Add more options to priority list
- [x] Handle the user pressing the back button
- [x] Add cypress tests for the relevant journeys 
- [ ] After going back, the forwards browser button does not work 