### PR TITLE
Allow multiple pages before repair description page

### DIFF
--- a/flow.js
+++ b/flow.js
@@ -77,7 +77,7 @@ class Flow {
       'repair-description-leak-inside': {prevStep: 'repair-description-leak-electrics', nextStep: 'repair-description-leak-source'},
       'repair-description-leak-source': {prevStep: 'repair-description-leak-inside', nextStep: 'repair-description'},
       'repair-leak-description-electrics-emergency': {prevStep: 'repair-description-leak-electrics'},
-      'repair-description': {prevStep:'repair-kitchen-cupboard-problems', nextStep: 'contact-person'},//need to investigate this as there are numerous prev steps, but it might just work
+      'repair-description': {prevStep:true, nextStep: 'contact-person'},//need to investigate this as there are numerous prev steps, but it might just work
       'contact-person': {prevStep: 'repair-description', nextStep:'contact-details'},
       'contact-details': {prevStep: 'contact-person', nextStep: 'repair-availability'},
       'repair-availability': {prevStep: 'contact-details', nextStep: 'summary'},
@@ -128,7 +128,11 @@ class Flow {
     // workout what the new previous step should be.
     if (this._prevStepIsNotDefinedOrEqualsCurrentStep(state)) {
       if (this._prevStepIsInFlow(state)) {
-        state.prevStep = this.flow[state.step].prevStep
+        if(state.step == 'repair-description' && (state.data.repairProblemBestDescription.value == "doorHangingOff" || state.data.repairProblemBestDescription.value == "doorMissing")){
+          state.prevStep ='repair-kitchen-cupboard-problems'
+        }else {
+          state.prevStep = this.flow[state.step].prevStep
+        }
       } else {
         return this.history.push('/')
       }

--- a/flow.js
+++ b/flow.js
@@ -77,7 +77,7 @@ class Flow {
       'repair-description-leak-inside': {prevStep: 'repair-description-leak-electrics', nextStep: 'repair-description-leak-source'},
       'repair-description-leak-source': {prevStep: 'repair-description-leak-inside', nextStep: 'repair-description'},
       'repair-leak-description-electrics-emergency': {prevStep: 'repair-description-leak-electrics'},
-      'repair-description': {prevStep:true, nextStep: 'contact-person'},//need to investigate this as there are numerous prev steps, but it might just work
+      'repair-description': {prevStep: true, nextStep: 'contact-person'},
       'contact-person': {prevStep: 'repair-description', nextStep:'contact-details'},
       'contact-details': {prevStep: 'contact-person', nextStep: 'repair-availability'},
       'repair-availability': {prevStep: 'contact-details', nextStep: 'summary'},

--- a/tests/unit/flow.test.js
+++ b/tests/unit/flow.test.js
@@ -131,6 +131,50 @@ describe('Flow', () => {
         expect(historySpy.push).toHaveBeenCalledWith('/');
       });
     })
+
+    describe('multiple previous step', ()=>{
+      test('redirects repair-kitchen-cupboard-problems when repairProblemBestDescription value is doorMissing', ()=>{
+        const state = {
+          prevStep: 'repair-description',
+          step: 'repair-description',
+          data: {
+            repairProblemBestDescription: {
+              value: 'doorMissing'
+            }
+          }
+        }
+        flow.prevStep(state);
+        expect(setStateSpy).toBeCalled();
+        expect(historySpy.push).toHaveBeenCalledWith('repair-kitchen-cupboard-problems');
+      });
+      test('redirects repair-kitchen-cupboard-problems when repairProblemBestDescription value is doorHangingOff', ()=>{
+        const state = {
+          prevStep: 'repair-description',
+          step: 'repair-description',
+          data: {
+            repairProblemBestDescription: {
+              value: 'doorHangingOff'
+            }
+          }
+        }
+        flow.prevStep(state);
+        expect(setStateSpy).toBeCalled();
+        expect(historySpy.push).toHaveBeenCalledWith('repair-kitchen-cupboard-problems');
+      });
+      test('does not redirect to repair-kitchen-cupboard-problems when repairProblemBestDescription value is random', ()=>{
+        const state = {
+          prevStep: 'repair-description',
+          step: 'repair-description',
+          data: {
+            repairProblemBestDescription: {
+              value: 'random'
+            }
+          }
+        }
+        flow.prevStep(state);
+        expect(historySpy.push).not.toHaveBeenCalledWith('repair-kitchen-cupboard-problems');
+      });
+    })
   });
 
   describe('handleChange', ()=> {


### PR DESCRIPTION
This pr allows you to manually select the previous page for repair description. Each time a page is added which could be previous page for repair description, this will need to be updated to reflect the changes extending the if statement. To refactor this, a mapper can be added.